### PR TITLE
Fix DeviceManagementProviderServiceMock methods

### DIFF
--- a/components/mobile-plugins/android-plugin/io.entgra.device.mgt.plugins.mobile.android.api/src/test/java/io/entgra/device/mgt/plugins/mobile/android/api/mocks/DeviceManagementProviderServiceMock.java
+++ b/components/mobile-plugins/android-plugin/io.entgra.device.mgt.plugins.mobile.android.api/src/test/java/io/entgra/device/mgt/plugins/mobile/android/api/mocks/DeviceManagementProviderServiceMock.java
@@ -882,7 +882,7 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
     }
 
     @Override
-    public List<Application> getInstalledApplicationsOnDevice(Device device, int i, int i1) throws DeviceManagementException {
+    public List<Application> getInstalledApplicationsOnDevice(Device device, int i, int i1, int i3) throws DeviceManagementException {
         return null;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1099,13 +1099,11 @@
     </properties>
 
     <scm>
-        <url>https://repository.entgra.net/community/device-mgt-plugins.git</url>
-        <developerConnection>scm:git:https://repository.entgra.net/community/device-mgt-plugins.git
-        </developerConnection>
-        <connection>scm:git:https://repository.entgra.net/community/device-mgt-plugins.git</connection>
+        <url>https://github.com/entgra/device-mgt-plugins.git</url>
+        <developerConnection>scm:git:https://github.com/entgra/device-mgt-plugins.git</developerConnection>
+        <connection>scm:git:https://github.com/entgra/device-mgt-plugins.git</connection>
         <tag>v6.0.14</tag>
     </scm>
-
 
     <build>
         <extensions>


### PR DESCRIPTION
## Purpose
- Fix DeviceManagementProviderServiceMock methods according to DeviceManagementProviderService
- Add github scm url to pom.xml
- Remove core, agent version bumps of previous release process


