### PR TITLE
Include timestamp value into the event payload

### DIFF
--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.extension/src/main/java/io/entgra/device/mgt/plugins/input/adapter/extension/transformer/MQTTContentTransformer.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.extension/src/main/java/io/entgra/device/mgt/plugins/input/adapter/extension/transformer/MQTTContentTransformer.java
@@ -71,9 +71,11 @@ public class MQTTContentTransformer implements ContentTransformer {
             throws ParseException {
         JSONParser parser = new JSONParser();
         JSONObject jsonObject = new JSONObject();
+        JSONObject payloadData = (JSONObject) parser.parse(msg);
+        payloadData.put("ts", System.currentTimeMillis());
         jsonObject.put("deviceId", deviceIdFromTopic);
         JSONObject eventObject = new JSONObject();
-        eventObject.put("payloadData", parser.parse(msg));
+        eventObject.put("payloadData", payloadData);
         eventObject.put("metaData", jsonObject);
         JSONObject event = new JSONObject();
         event.put("event", eventObject);


### PR DESCRIPTION
## Purpose
> since timestamp value is common in event stream templates, instead of sending it in every event payload from device side, time is calculated from the server. This will also make it easier to keep a consistent time log in the database without having concern about the specific time clocks in device. Due to this change time will be stored after the event message is arrived at the server, making the time closer to the arrived time, rather than the sent time. 
Can be useful in identifying any lags in message sending from device side and arriving at server side, by maintaining another time for sent time in the paylod.

example row in EVENT_DB: 

mysql> SELECT * FROM table_eventNormal_air_quality_carbonsuper_rdbms_publisher;
+-------+--------+-------+------+------+--------+--------+---------+--------+--------+--------+------+---------------+------+------+-------+------+------+---------------+
| APM10 | APM100 | APM25 | CO2  | CT   | GT03UM | GT05UM | GT100UM | GT10UM | GT25UM | GT50UM | H    | META_DEVICEID | P    | PM10 | PM100 | PM25 | T    | TS            |
+-------+--------+-------+------+------+--------+--------+---------+--------+--------+--------+------+---------------+------+------+-------+------+------+---------------+
|    42 |     42 |    42 | 3.14 | 3.14 |     42 |     42 |      42 |     42 |     42 |     42 | 3.14 | aq02          | 3.14 |   42 |    42 |   42 | 3.14 | 1746626107676 |
+-------+--------+-------+------+------+--------+--------+---------+--------+--------+--------+------+---------------+------+------+-------+------+------+---------------+


