### PR TITLE
Refactor username, password and error handling in exserver

### DIFF
--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/pom.xml
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/pom.xml
@@ -75,6 +75,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.entgra.device.mgt.core</groupId>
+            <artifactId>io.entgra.device.mgt.core.device.mgt.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.ops4j.pax.logging</groupId>
             <artifactId>pax-logging-api</artifactId>
             <scope>provided</scope>

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
@@ -26,7 +26,6 @@ import com.google.protobuf.GeneratedMessageV3;
 import io.entgra.device.mgt.core.device.mgt.common.DeviceIdentifier;
 import io.entgra.device.mgt.core.device.mgt.common.EnrolmentInfo;
 import io.entgra.device.mgt.core.device.mgt.common.exceptions.DeviceManagementException;
-import io.entgra.device.mgt.core.device.mgt.core.config.DeviceConfigurationManager;
 import io.entgra.device.mgt.core.device.mgt.core.config.keymanager.KeyManagerConfigurations;
 import io.entgra.device.mgt.core.device.mgt.core.service.DeviceManagementProviderService;
 import io.grpc.Server;
@@ -55,68 +54,64 @@ import java.util.concurrent.TimeUnit;
 
 import static io.entgra.device.mgt.plugins.emqx.exhook.HandlerConstants.MIN_TOKEN_LENGTH;
 
-public class ExServer {
-    private static final Log logger = LogFactory.getLog(ExServer.class.getName());
+    public class ExServer {
+        private static final Log logger = LogFactory.getLog(ExServer.class.getName());
 
-    private static Map<String, String> accessTokenMap = new ConcurrentHashMap<>();
-    private static Map<String, String> authorizedScopeMap = new ConcurrentHashMap<>();
-    private Server server;
+        private static Map<String, String> accessTokenMap = new ConcurrentHashMap<>();
+        private static Map<String, String> authorizedScopeMap = new ConcurrentHashMap<>();
+        private Server server;
+        private final ExServerUtilityService utilityService;
+        public ExServer(ExServerUtilityService utilityService) {
+            this.utilityService = utilityService;
+        }
 
-    public ExServer() {
-    }
+        public void start() throws IOException {
+            /* The port on which the server should run */
+            int port = 9000;
 
-    public void start() throws IOException {
-        /* The port on which the server should run */
-        int port = 9000;
-
-        server = ServerBuilder.forPort(port)
-                .addService(new HookProviderImpl())
-                .build()
-                .start();
-        logger.info("Server started, listening on " + port);
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                // Use stderr here since the logger may have been reset by its JVM shutdown hook.
-                System.err.println("*** shutting down gRPC server since JVM is shutting down");
-                try {
-                    ExServer.this.stop();
-                } catch (InterruptedException e) {
-                    e.printStackTrace(System.err);
+            server = ServerBuilder.forPort(port)
+                    .addService(new HookProviderImpl(utilityService))
+                    .build()
+                    .start();
+            logger.info("Server started, listening on " + port);
+            Runtime.getRuntime().addShutdownHook(new Thread() {
+                @Override
+                public void run() {
+                    // Use stderr here since the logger may have been reset by its JVM shutdown hook.
+                    System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                    try {
+                        ExServer.this.stop();
+                    } catch (InterruptedException e) {
+                        e.printStackTrace(System.err);
+                    }
+                    System.err.println("*** server shut down");
                 }
-                System.err.println("*** server shut down");
+            });
+        }
+
+        public void stop() throws InterruptedException {
+            if (server != null) {
+                server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
             }
-        });
-    }
-
-    public void stop() throws InterruptedException {
-        if (server != null) {
-            server.shutdown().awaitTermination(30, TimeUnit.SECONDS);
         }
-    }
 
-    /**
-     * Await termination on the main thread since the grpc library uses daemon threads.
-     */
-    public void blockUntilShutdown() throws InterruptedException {
-        if (server != null) {
-            server.awaitTermination();
+        /**
+         * Await termination on the main thread since the grpc library uses daemon threads.
+         */
+        public void blockUntilShutdown() throws InterruptedException {
+            if (server != null) {
+                server.awaitTermination();
+            }
         }
-    }
-
-    /**
-     * Main launches the server from the command line.
-     */
-    public static void main(String[] args) throws IOException, InterruptedException {
-        final ExServer server = new ExServer();
-        server.start();
-        server.blockUntilShutdown();
-    }
 
     static class HookProviderImpl extends HookProviderGrpc.HookProviderImplBase {
 
         public void DEBUG(String fn, Object req) {
             logger.debug(fn + ", request: " + req);
+        }
+        private final ExServerUtilityService utilityService;
+        public HookProviderImpl(ExServerUtilityService utilityService) {
+            this.utilityService = utilityService;
         }
 
         @Override
@@ -280,19 +275,35 @@ public class ExServer {
                 respondGrpcError(responseObserver, e, "gRPC status error during client authentication");
             } catch (ExServerException e) {
                 respondGrpcError(responseObserver, e, "Unexpected error in onClientAuthenticate");
+            } catch (RuntimeException e) {
+                respondGrpcError(responseObserver, e, "Unexpected error in onClientAuthenticate");
             }
         }
 
+        /**
+         * Attempts to authenticate a client using the provided OAuth token by
+         * introspecting it against the configured Key Manager server.
+         *
+         * <p>This method sends a token introspection HTTP POST request to the
+         * Key Manager's introspection endpoint. If the token is valid and active,
+         * it updates the internal access and scope maps and responds with a
+         * successful gRPC response. Otherwise, it responds with an appropriate
+         * gRPC error status.</p>
+         *
+         * @param token the OAuth token to authenticate
+         * @param responseObserver the gRPC stream observer to send the response or error
+         * @param clientId the client identifier associated with the token
+         * @throws IOException if an I/O error occurs while sending the introspection request
+         */
         private void tryAuthenticateWithToken(String token, StreamObserver<ValuedResponse> responseObserver,
                                               String clientId) throws ExServerException {
             try {
-                KeyManagerConfigurations keyManagerConfig = DeviceConfigurationManager.getInstance()
-                        .getDeviceManagementConfig().getKeyManagerConfigurations();
-                HttpPost tokenEndpoint = new HttpPost(keyManagerConfig.getServerUrl() + HandlerConstants.INTROSPECT_ENDPOINT);
+                KeyManagerConfigurations kmConfig = utilityService.getKeyManagerConfigurations();
+                HttpPost tokenEndpoint = new HttpPost(kmConfig.getServerUrl() + HandlerConstants.INTROSPECT_ENDPOINT);
                 tokenEndpoint.setHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_FORM_URLENCODED.toString());
                 tokenEndpoint.setHeader(HttpHeaders.AUTHORIZATION, HandlerConstants.BASIC +
-                        Base64.getEncoder().encodeToString((keyManagerConfig.getAdminUsername() + HandlerConstants.COLON +
-                                keyManagerConfig.getAdminPassword()).getBytes()));
+                        Base64.getEncoder().encodeToString((kmConfig.getAdminUsername() + HandlerConstants.COLON +
+                                kmConfig.getAdminPassword()).getBytes()));
                 tokenEndpoint.setEntity(new StringEntity("token=" + token, ContentType.APPLICATION_FORM_URLENCODED));
 
                 ProxyResponse tokenStatus = HandlerUtil.execute(tokenEndpoint);
@@ -520,16 +531,17 @@ public class ExServer {
             ByteString bstr = ByteString.copyFromUtf8("hardcode payload by exhook-svr-java :)");
 
             Message nmsg = Message.newBuilder()
-                                  .setId     (request.getMessage().getId())
-                                  .setNode   (request.getMessage().getNode())
-                                  .setFrom   (request.getMessage().getFrom())
-                                  .setTopic  (request.getMessage().getTopic())
-                                  .setPayload(((GeneratedMessageV3) request).toByteString()).build();
+                    .setId(request.getMessage().getId())
+                    .setNode(request.getMessage().getNode())
+                    .setFrom(request.getMessage().getFrom())
+                    .setTopic(request.getMessage().getTopic())
+                    .setPayload(((GeneratedMessageV3) request).toByteString()).build();
+            //.setPayload(request.getMessage().getPayload())  //  clean, expected by MQTT clients
 
 
             ValuedResponse reply = ValuedResponse.newBuilder()
-                                                 .setType(ValuedResponse.ResponsedType.STOP_AND_RETURN)
-                                                 .setMessage(nmsg).build();
+                    .setType(ValuedResponse.ResponsedType.STOP_AND_RETURN)
+                    .setMessage(nmsg).build();
             responseObserver.onNext(reply);
             responseObserver.onCompleted();
         }
@@ -583,6 +595,18 @@ public class ExServer {
 
         }
 
+        /**
+         * Handles and responds to gRPC errors by logging the error and sending
+         * an appropriate error status to the provided gRPC response observer.
+         *
+         * <p>If the throwable is already a {@link StatusRuntimeException}, it is
+         * sent directly to the observer. Otherwise, an INTERNAL status with the
+         * provided message and cause is created and sent.</p>
+         *
+         * @param observer the gRPC response observer to send the error to
+         * @param e the throwable representing the error
+         * @param msg a descriptive message to log and include in the gRPC error response
+         */
         private void respondGrpcError(StreamObserver<?> observer, Throwable e, String msg) {
             if (e instanceof StatusRuntimeException) {
                 logger.error(msg, e);
@@ -593,4 +617,5 @@ public class ExServer {
             }
         }
     }
+
 }

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
@@ -358,11 +358,9 @@ public class ExServer {
                 ClientCheckAclRequest.AclReqType aclType = request.getType();
                 //todo: check token validity
                 String accessToken = accessTokenMap.get(request.getClientinfo().getClientid());
-                if (StringUtils.isEmpty(accessToken) ||
-                        !((!StringUtils.isEmpty(username) && accessToken.startsWith(username)) ||
-                                (!StringUtils.isEmpty(password) && accessToken.startsWith(password)))) {
+                if (StringUtils.isEmpty(accessToken)) {
                     throw Status.PERMISSION_DENIED
-                            .withDescription("Access token missing or does not match username or password")
+                            .withDescription("Access token not found for clientId: " + request.getClientinfo().getClientid())
                             .asRuntimeException();
                 }
 

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
@@ -240,6 +240,10 @@ public class ExServer {
             String clientId = request.getClientinfo().getClientid();
 
             try {
+                if (StringUtils.isEmpty(clientId)) {
+                    throw new ExServerException("Client ID is missing in the request");
+                }
+
                 if (StringUtils.isEmpty(username) && StringUtils.isEmpty(password)) {
                     throw Status.INVALID_ARGUMENT.
                             withDescription("Username and password are both empty.Either username, password or both must be provided").
@@ -266,26 +270,21 @@ public class ExServer {
                 }
 
                 for (String tokenCandidate : possibleTokens) {
-                    try {
-                        tryAuthenticateWithToken(tokenCandidate, responseObserver, clientId);
-                        return; // success
-                    } catch (IOException e) {
-                        logger.warn("Failed token attempt with: " + tokenCandidate);
-                        // Try next candidate
-                    }
+                    tryAuthenticateWithToken(tokenCandidate, responseObserver, clientId);
+                    return; // success
                 }
 
                 // All attempts failed
                 throw Status.UNAUTHENTICATED.withDescription("Invalid or expired token").asRuntimeException();
             } catch (StatusRuntimeException e) {
                 respondGrpcError(responseObserver, e, "gRPC status error during client authentication");
-            } catch (Exception e) {
+            } catch (ExServerException e) {
                 respondGrpcError(responseObserver, e, "Unexpected error in onClientAuthenticate");
             }
         }
 
         private void tryAuthenticateWithToken(String token, StreamObserver<ValuedResponse> responseObserver,
-                                              String clientId) throws IOException {
+                                              String clientId) throws ExServerException {
             try {
                 KeyManagerConfigurations keyManagerConfig = DeviceConfigurationManager.getInstance()
                         .getDeviceManagementConfig().getKeyManagerConfigurations();
@@ -332,7 +331,7 @@ public class ExServer {
                 responseObserver.onCompleted();
             } catch (StatusRuntimeException e) {
                 respondGrpcError(responseObserver, e, "gRPC status error");  // proper gRPC status error
-            } catch (Exception e) {
+            } catch (IOException e) {
                 respondGrpcError(responseObserver, e, "Unexpected error during authentication");
             }
         }
@@ -347,16 +346,13 @@ public class ExServer {
                 republished/deviceType
              */
             try {
-                String username = request.getClientinfo().getUsername();
-                String password = request.getClientinfo().getPassword();
-                String topic = request.getTopic();
-                if (StringUtils.isEmpty(username) && StringUtils.isEmpty(password)) {
-                    throw Status.INVALID_ARGUMENT
-                            .withDescription("Username and password are both empty. Either username, password or both must be provided")
-                            .asRuntimeException();
-                }
-                ClientCheckAclRequest.AclReqType aclType = request.getType();
                 //todo: check token validity
+                String clientId = request.getClientinfo().getClientid();
+                if (StringUtils.isEmpty(clientId)) {
+                    throw new ExServerException("Client ID is missing in the request");
+                }
+                String topic = request.getTopic();
+                ClientCheckAclRequest.AclReqType aclType = request.getType();
                 String accessToken = accessTokenMap.get(request.getClientinfo().getClientid());
                 if (StringUtils.isEmpty(accessToken)) {
                     throw Status.PERMISSION_DENIED
@@ -400,7 +396,7 @@ public class ExServer {
 
                 boolean isAuthorized = scopeList.stream().anyMatch(scope -> scope.startsWith(tempScope));
                 if (!isAuthorized) {
-                    logger.warn("ACL denied: user=" + username + ", topic=" + topic + ", requiredScope=" + tempScope);
+                    logger.warn("topic=" + topic + ", requiredScope=" + tempScope);
                     throw Status.PERMISSION_DENIED.withDescription("User not authorized for requested topic").asRuntimeException();
                 }
 
@@ -414,7 +410,7 @@ public class ExServer {
                 responseObserver.onCompleted();
             } catch (StatusRuntimeException e) {
                 respondGrpcError(responseObserver, e, "ACL check failed: " + e.getStatus().getDescription());
-            } catch (Exception e) {
+            } catch (ExServerException e) {
                 respondGrpcError(responseObserver, e, "Unexpected error during ACL check");
             }
         }

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServerException.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServerException.java
@@ -1,0 +1,38 @@
+package io.entgra.device.mgt.plugins.emqx.exhook;
+
+public class ExServerException extends Exception{
+
+    private static final long serialVersionUID = -2310817253324129270L;
+    private String errorMessage;
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public ExServerException(String msg, Exception nestedEx) {
+        super(msg, nestedEx);
+        setErrorMessage(msg);
+    }
+
+    public ExServerException(String message, Throwable cause) {
+        super(message, cause);
+        setErrorMessage(message);
+    }
+
+    public ExServerException(String msg) {
+        super(msg);
+        setErrorMessage(msg);
+    }
+
+    public ExServerException() {
+        super();
+    }
+
+    public ExServerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServerUtilityService.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServerUtilityService.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ *
+ * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.entgra.device.mgt.plugins.emqx.exhook;
+
+import io.entgra.device.mgt.core.device.mgt.core.config.keymanager.KeyManagerConfigurations;
+
+public interface ExServerUtilityService {
+
+    KeyManagerConfigurations getKeyManagerConfigurations();
+}

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/HandlerConstants.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/HandlerConstants.java
@@ -25,4 +25,5 @@ public class HandlerConstants {
     public static final String TOKEN_IS_EXPIRED = "ACCESS_TOKEN_IS_EXPIRED";
     public static final String COLON = ":";
     public static final int INTERNAL_ERROR_CODE = 500;
+    public static final int MIN_TOKEN_LENGTH = 36;
 }

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/HandlerUtil.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/HandlerUtil.java
@@ -30,8 +30,16 @@ import org.apache.http.impl.client.HttpClients;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
-import java.io.*;
-import java.security.*;
+import java.io.BufferedReader;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
 
 public class HandlerUtil {
@@ -56,7 +64,6 @@ public class HandlerUtil {
     private static final String SSLV3 = "SSLv3";
 
     private static final Log log = LogFactory.getLog(HandlerUtil.class);
-
     /***
      *
      * @param httpRequest - httpMethod e.g:- HttpPost, HttpGet
@@ -276,5 +283,4 @@ public class HandlerUtil {
             return responseBuilder.toString();
         }
     }
-
 }

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.initializer/pom.xml
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.initializer/pom.xml
@@ -51,6 +51,16 @@
             <artifactId>pax-logging-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.entgra.device.mgt.core</groupId>
+            <artifactId>io.entgra.device.mgt.core.device.mgt.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.entgra.device.mgt.core</groupId>
+            <artifactId>io.entgra.device.mgt.core.device.mgt.common</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <extensions>
@@ -72,12 +82,16 @@
                         <Bundle-Description>io.entgra.device.mgt.plugins.emqx.initializer</Bundle-Description>
                         <Private-Package>io.entgra.device.mgt.plugins.emqx.initializer.internal</Private-Package>
                         <Import-Package>
+                            io.entgra.device.mgt.core.device.mgt.core.config;version="${io.entgra.device.mgt.core.version.range}",
+                            io.entgra.device.mgt.core.device.mgt.core.config.keymanager;version="${io.entgra.device.mgt.core.version.range}",
+                            io.entgra.device.mgt.core.device.mgt.core.service;version="${io.entgra.device.mgt.core.version.range}",
                             io.entgra.device.mgt.plugins.emqx.exhook,
                             io.entgra.device.mgt.plugins.emqx.initializer,
-                            org.apache.commons.logging;version="[1.2 ,2)",
-                            org.osgi.framework.*;version="${imp.package.version.osgi.framework}",
-                            org.osgi.service.*;version="${imp.package.version.osgi.service}",
-                            org.wso2.carbon.core;version="[4.8,5)"
+                            org.apache.commons.logging;version="${commons.logging.version.range}",
+                            org.osgi.framework;version="${imp.package.version.osgi.framework}",
+                            org.osgi.service.component;version="${imp.package.version.osgi.service}",
+                            org.wso2.carbon.context;version="${carbon.kernel.version}",
+                            org.wso2.carbon.core;version="${carbon.kernel.version}"
                         </Import-Package>
                         <Export-Package>
                             !io.entgra.device.mgt.plugins.emqx.initializer.internal,

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.initializer/src/main/java/io/entgra/device/mgt/plugins/emqx/initializer/ExServerUtilityServiceImpl.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.initializer/src/main/java/io/entgra/device/mgt/plugins/emqx/initializer/ExServerUtilityServiceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 - 2023, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
+ * Copyright (c) 2018 - 2025, Entgra (Pvt) Ltd. (http://www.entgra.io) All Rights Reserved.
  *
  * Entgra (Pvt) Ltd. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -15,23 +15,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.entgra.device.mgt.plugins.emqx.initializer.internal;
+package io.entgra.device.mgt.plugins.emqx.initializer;
 
+import io.entgra.device.mgt.core.device.mgt.core.config.keymanager.KeyManagerConfigurations;
 import io.entgra.device.mgt.core.device.mgt.core.service.DeviceManagementProviderService;
+import io.entgra.device.mgt.plugins.emqx.exhook.ExServerUtilityService;
 
-public class EmqxExhookDataHolder {
+public class ExServerUtilityServiceImpl implements ExServerUtilityService {
 
-    private static final EmqxExhookDataHolder thisInstance = new EmqxExhookDataHolder();
-    private DeviceManagementProviderService deviceManagementProviderService;
-    public static EmqxExhookDataHolder getInstance() {
-        return thisInstance;
-    }
+    private final DeviceManagementProviderService deviceManagementProviderService;
 
-    public DeviceManagementProviderService getDeviceManagementProviderService() {
-        return deviceManagementProviderService;
-    }
-
-    public void setDeviceManagementProviderService(DeviceManagementProviderService deviceManagementProviderService) {
+    public ExServerUtilityServiceImpl(DeviceManagementProviderService deviceManagementProviderService) {
         this.deviceManagementProviderService = deviceManagementProviderService;
+    }
+    @Override
+    public KeyManagerConfigurations getKeyManagerConfigurations() {
+        return deviceManagementProviderService.getDeviceManagementConfig().getKeyManagerConfigurations();
     }
 }

--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.initializer/src/main/java/io/entgra/device/mgt/plugins/emqx/initializer/internal/EmqxExhookServiceComponent.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.initializer/src/main/java/io/entgra/device/mgt/plugins/emqx/initializer/internal/EmqxExhookServiceComponent.java
@@ -17,6 +17,7 @@
  */
 package io.entgra.device.mgt.plugins.emqx.initializer.internal;
 
+import io.entgra.device.mgt.core.device.mgt.core.service.DeviceManagementProviderService;
 import io.entgra.device.mgt.plugins.emqx.initializer.EmqxExhookInitializer;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -59,6 +60,26 @@ public class EmqxExhookServiceComponent {
             }
         } catch (Throwable e) {
             log.error("Error occurred while de-activating EmqxExhookServiceComponent", e);
+        }
+    }
+
+    @Reference(
+            name = "device.mgt.provider.service",
+            service = io.entgra.device.mgt.core.device.mgt.core.service.DeviceManagementProviderService.class,
+            cardinality = ReferenceCardinality.MANDATORY,
+            policy = ReferencePolicy.DYNAMIC,
+            unbind = "unsetDeviceManagementServiceProviderService")
+    protected void setDeviceManagementServiceProviderService(DeviceManagementProviderService deviceManagementProviderService) {
+        EmqxExhookDataHolder.getInstance().setDeviceManagementProviderService(deviceManagementProviderService);
+        if (log.isDebugEnabled()) {
+            log.debug("Device management provider service is set successfully");
+        }
+    }
+
+    protected void unsetDeviceManagementServiceProviderService(DeviceManagementProviderService deviceManagementProviderService) {
+        EmqxExhookDataHolder.getInstance().setDeviceManagementProviderService(null);
+        if (log.isDebugEnabled()) {
+            log.debug("Device management provider service is unset successfully");
         }
     }
 }

--- a/components/mobile-plugins/android-plugin/io.entgra.device.mgt.plugins.mobile.android.api/src/test/java/io/entgra/device/mgt/plugins/mobile/android/api/mocks/DeviceManagementProviderServiceMock.java
+++ b/components/mobile-plugins/android-plugin/io.entgra.device.mgt.plugins.mobile.android.api/src/test/java/io/entgra/device/mgt/plugins/mobile/android/api/mocks/DeviceManagementProviderServiceMock.java
@@ -58,6 +58,7 @@ import io.entgra.device.mgt.core.device.mgt.common.push.notification.Notificatio
 import io.entgra.device.mgt.core.device.mgt.common.spi.DeviceManagementService;
 import io.entgra.device.mgt.core.device.mgt.common.type.mgt.DeviceStatus;
 import io.entgra.device.mgt.core.device.mgt.core.cache.DeviceCacheKey;
+import io.entgra.device.mgt.core.device.mgt.core.config.DeviceManagementConfig;
 import io.entgra.device.mgt.core.device.mgt.core.dao.DeviceManagementDAOException;
 import io.entgra.device.mgt.core.device.mgt.core.dto.DeviceDetailsDTO;
 import io.entgra.device.mgt.core.device.mgt.core.dto.DeviceType;
@@ -982,6 +983,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
 
     @Override
     public List<Integer> getDeviceIdsByStatus(List<String> list) throws DeviceManagementException {
+        return null;
+    }
+
+    @Override
+    public DeviceManagementConfig getDeviceManagementConfig() {
         return null;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1016,7 +1016,7 @@
         <commons-io-wso2.version>2.4.0.wso2v1</commons-io-wso2.version>
 
         <commons.lang.version>2.4</commons.lang.version>
-
+        <commons.logging.version.range>[1.2,2)</commons.logging.version.range>
 
         <orbit.version.commons-httpclient>3.1.0.wso2v2</orbit.version.commons-httpclient>
         <commons-codec.version.wso2>1.4.0.wso2v1</commons-codec.version.wso2>


### PR DESCRIPTION
## Purpose
Currently username and password is restricted to have at least one character in them.There is a requirement that either one can be empty, either one can have full access token.

mqtt specs [MQTT-3.1.2-18] to [MQTT-3.1.2-22] was referenced to optimize token try out order for introsepction starting from username.

mqtt specs
If the User Name Flag is set to 0, a user name MUST NOT be present in the payload [MQTT-3.1.2-18].
If the User Name Flag is set to 1, a user name MUST be present in the payload [MQTT-3.1.2-19].
If the Password Flag is set to 0, a password MUST NOT be present in the payload [MQTT-3.1.2-20].
If the Password Flag is set to 1, a password MUST be present in the payload [MQTT-3.1.2-21].
If the User Name Flag is set to 0, the Password Flag MUST be set to 0 [MQTT-3.1.2-22].