### PR TITLE
Fix message publish payload

### DIFF
--- a/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
+++ b/components/extensions/emqx-extensions/io.entgra.device.mgt.plugins.emqx.exhook/src/main/java/io/entgra/device/mgt/plugins/emqx/exhook/ExServer.java
@@ -529,8 +529,7 @@ public class ExServer {
                     .setNode(request.getMessage().getNode())
                     .setFrom(request.getMessage().getFrom())
                     .setTopic(request.getMessage().getTopic())
-                    .setPayload(((GeneratedMessageV3) request).toByteString()).build();
-            //.setPayload(request.getMessage().getPayload())  //  clean, expected by MQTT clients
+                    .setPayload(request.getMessage().getPayload()).build();
 
 
             ValuedResponse reply = ValuedResponse.newBuilder()


### PR DESCRIPTION
## Purpose
Ticket : https://roadmap.entgra.net/issues/13275
MQTT clients previously recieved a protbuf encoded payload msg when using routing the messages with grpc auth.
This had unnecessary meta data for external mqtt clients.
Exact payload message was extracted and forwarded which is ideal for both external mqtt clients as well as when the iot server has internal clients subscribed  to the same topic and receive the message from an internal client.