### PR TITLE
Add getAllDeviceLocationInfo method to mock test

### DIFF
--- a/components/mobile-plugins/android-plugin/io.entgra.device.mgt.plugins.mobile.android.api/src/test/java/io/entgra/device/mgt/plugins/mobile/android/api/mocks/DeviceManagementProviderServiceMock.java
+++ b/components/mobile-plugins/android-plugin/io.entgra.device.mgt.plugins.mobile.android.api/src/test/java/io/entgra/device/mgt/plugins/mobile/android/api/mocks/DeviceManagementProviderServiceMock.java
@@ -714,6 +714,11 @@ public class DeviceManagementProviderServiceMock implements DeviceManagementProv
     }
 
     @Override
+    public List<DeviceLocationHistorySnapshot> getAllDeviceLocationInfo(String deviceType, long exactTime, int timeWindow, PaginationRequest paginationRequest) throws DeviceManagementException {
+        return List.of();
+    }
+
+    @Override
     public void notifyPullNotificationSubscriber(Device device, Operation operation)
             throws PullNotificationExecutionFailedException {
     }


### PR DESCRIPTION
## Purpose
> Adding the new getAllDeviceLocationInfo method for the DeviceManagementProviderServiceMock testing case.