### PR TITLE
Add MQTT message payload compression and decompression functionality

### DIFF
--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/pom.xml
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/pom.xml
@@ -91,6 +91,11 @@
             <artifactId>io.entgra.device.mgt.core.apimgt.extension.rest.api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${fasterxml.jackson.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
@@ -41,6 +41,9 @@ import org.wso2.carbon.event.input.adapter.core.InputEventAdapterConfiguration;
 import org.wso2.carbon.event.input.adapter.core.InputEventAdapterListener;
 import org.wso2.carbon.event.input.adapter.core.exception.InputEventAdapterRuntimeException;
 import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -48,6 +51,7 @@ import java.util.Map;
 
 public class MQTTAdapterListener implements MqttCallback, Runnable {
     private static final Log log = LogFactory.getLog(MQTTAdapterListener.class);
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private MqttClient mqttClient;
     private MqttConnectOptions connectionOptions;
@@ -231,18 +235,43 @@ public class MQTTAdapterListener implements MqttCallback, Runnable {
 
             // Check if mqttMsgString null or empty
             if (StringUtils.isEmpty(mqttMsgString)) {
-                log.warn("Empty MqttMessage Received");
+                log.warn("Empty Mqtt Message Received");
                 return;
             }
-            int startIndex = mqttMsgString.indexOf("{");
-            int endIndex = mqttMsgString.lastIndexOf("}");
 
-            // Validate indices before substring
-            if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
-                log.error("Invalid message format - missing or malformed JSON braces");
-                return;
+            // Parse the incoming message as JSON using Jackson. Avoid manual indexOf/lastIndexOf
+            // which can be incorrect when payloads contain additional braces or non-JSON content.
+            String msgText;
+            try {
+                // Attempt to parse the message as JSON
+                JsonNode jsonNode = OBJECT_MAPPER.readTree(mqttMsgString);
+                if (jsonNode.isObject() || jsonNode.isArray()) {
+                    msgText = OBJECT_MAPPER.writeValueAsString(jsonNode);
+                } else if (jsonNode.isValueNode()) {
+                    msgText = jsonNode.asText();
+                } else {
+                    msgText = mqttMsgString;
+                }
+            } catch (JsonProcessingException ex) {
+                // JSON parsing failed - attempt to extract JSON from raw message as fallback
+                if (log.isDebugEnabled()) {
+                    log.debug("Payload is not valid JSON, attempting to extract JSON from raw message using " +
+                            "indexOf/lastIndexOf");
+                }
+
+                // Find the first '{' and last '}' to extract potential JSON content
+                int startIndex = mqttMsgString.indexOf("{");
+                int endIndex = mqttMsgString.lastIndexOf("}");
+
+                // Validate indices before substring to prevent malformed extraction
+                if (startIndex == -1 || endIndex == -1 || startIndex >= endIndex) {
+                    log.error("Invalid message format - missing or malformed JSON braces");
+                    return;
+                }
+
+                // Extract the JSON portion from the raw message
+                msgText = mqttMsgString.substring(startIndex, endIndex + 1);
             }
-            String msgText = mqttMsgString.substring(startIndex, endIndex + 1);
 
             PrivilegedCarbonContext.startTenantFlow();
             PrivilegedCarbonContext.getThreadLocalCarbonContext().setTenantDomain(tenantDomain, true);

--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTUtil.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTUtil.java
@@ -87,6 +87,15 @@ public class MQTTUtil {
 		}
 	}
 
+	/**
+	 * Find the byte offset of the GZIP header in the given payload.
+	 * <p>
+	 * Searches for the GZIP magic bytes (0x1f 0x8b) in the payload and returns
+	 * the offset of the first occurrence.
+	 *
+	 * @param payload the byte array to search for the GZIP header
+	 * @return the byte offset where the GZIP header starts, or -1 if not found
+	 */
 	public static int findGzipHeaderOffset(byte[] payload) {
 		// Find the offset of the gzip header (gzip magic bytes -> 0x1f 0x8b)
 		for (int i = 0; i < payload.length - 1; i++) {
@@ -98,6 +107,17 @@ public class MQTTUtil {
 		return -1;
 	}
 
+	/**
+	 * Decompress a GZIP-compressed message embedded in {@code payload} starting at the given {@code offset}.
+	 * <p>
+	 * The method opens a stream from {@code offset} to the end of {@code payload}, inflates the GZIP data,
+	 * converts the decompressed bytes to a String and then parses that JSON string into a String using Gson.
+	 *
+	 * @param payload original payload containing GZIP-compressed data
+	 * @param offset  byte offset where the GZIP header (0x1f 0x8b) starts
+	 * @return the decompressed message as a String
+	 * @throws IOException if an I/O error occurs during decompression
+	 */
 	public static String decompressMqttMsgFromOffset(byte[] payload, int offset) throws IOException {
 		// From original payload, start reading from gzip header offset
 		try (ByteArrayInputStream byteArrayInputStream =

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/pom.xml
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>io.entgra.device.mgt.core.apimgt.extension.rest.api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.entgra.device.mgt.core</groupId>
+            <artifactId>io.entgra.device.mgt.core.device.mgt.core</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>
@@ -132,7 +137,9 @@
                             org.wso2.carbon.context;version="[4.8,5)",
                             org.wso2.carbon.event.output.adapter.core;version="[5.3,6)",
                             org.wso2.carbon.event.output.adapter.core.exception;version="[5.3,6)",
-                            org.wso2.carbon.user.api;version="[1.0,2)"
+                            org.wso2.carbon.user.api;version="[1.0,2)",
+                            io.entgra.device.mgt.core.device.mgt.core.config;version="[5.2,6)",
+                            io.entgra.device.mgt.core.device.mgt.core.config.mqtt;version="[5.2,6)"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/pom.xml
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/pom.xml
@@ -138,8 +138,8 @@
                             org.wso2.carbon.event.output.adapter.core;version="[5.3,6)",
                             org.wso2.carbon.event.output.adapter.core.exception;version="[5.3,6)",
                             org.wso2.carbon.user.api;version="[1.0,2)",
-                            io.entgra.device.mgt.core.device.mgt.core.config;version="[5.2,6)",
-                            io.entgra.device.mgt.core.device.mgt.core.config.mqtt;version="[5.2,6)"
+                            io.entgra.device.mgt.core.device.mgt.core.config;version="${io.entgra.device.mgt.core.version.range}",
+                            io.entgra.device.mgt.core.device.mgt.core.config.mqtt;version="${io.entgra.device.mgt.core.version.range}"
                         </Import-Package>
                     </instructions>
                 </configuration>

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/MQTTEventAdapter.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/MQTTEventAdapter.java
@@ -54,6 +54,11 @@ public class MQTTEventAdapter implements OutputEventAdapter {
     private int tenantId;
     private MQTTBrokerConnectionConfiguration mqttBrokerConnectionConfiguration;
     private static final int DEFAULT_COMPRESSION_THRESHOLD_KB = 4;
+    /**
+     * Number of bytes in a kilobyte (1024). Use for byte <-> KB conversions.
+     */
+    private static final int BYTES_IN_KB = 1024;
+
 
     public MQTTEventAdapter(OutputEventAdapterConfiguration eventAdapterConfiguration,
                             Map<String, String> globalProperties) {
@@ -137,22 +142,27 @@ public class MQTTEventAdapter implements OutputEventAdapter {
         try {
             String mqttMessage = new Gson().toJson(message);
             byte[] rawBytes = mqttMessage.getBytes(StandardCharsets.UTF_8);
-            //Compress mqttMessage only if payload size >= configuredThresholdKb value (default 4KB)
-            int configuredThresholdKb = DeviceConfigurationManager.getInstance().getDeviceManagementConfig()
-                    .getMqttConfiguration().getCompressionThresholdKb();
-            int compressionThresholdKb = (configuredThresholdKb > 0) ? configuredThresholdKb :
-                    DEFAULT_COMPRESSION_THRESHOLD_KB;
 
-            if (rawBytes.length >= compressionThresholdKb * 1024) {
-                byte[] compressMqttMessage = MQTTUtil.compressMqttMessage(rawBytes);
-                if (log.isDebugEnabled()) {
-                    log.debug("Payload compressed. Original: " + rawBytes.length + "bytes, Compressed: " +
-                            compressMqttMessage.length + " bytes");
+            int configuredCompressionLevel = DeviceConfigurationManager.getInstance().getDeviceManagementConfig()
+                    .getMqttConfiguration().getCompressionLevel();
+            // Compress mqttMessage only if compression level is not 0 and payload size >= configuredThresholdKb
+            if (configuredCompressionLevel != 0) {
+                int configuredThresholdKb = DeviceConfigurationManager.getInstance().getDeviceManagementConfig()
+                        .getMqttConfiguration().getCompressionThresholdKb();
+                int compressionThresholdKb = (configuredThresholdKb > 0) ? configuredThresholdKb :
+                        DEFAULT_COMPRESSION_THRESHOLD_KB;
+                // Compress mqttMessage only if payload size >= configuredThresholdKb value (default 4KB)
+                if (rawBytes.length >= compressionThresholdKb * BYTES_IN_KB) {
+                    byte[] compressMqttMessage = MQTTUtil.compressMqttMessage(rawBytes);
+                    if (log.isDebugEnabled()) {
+                        log.debug("Payload compressed. Original: " + rawBytes.length + "bytes, Compressed: " +
+                                compressMqttMessage.length + " bytes");
+                    }
+                    threadPoolExecutor.submit(new MQTTSender(topic, compressMqttMessage));
+                    return;
                 }
-                threadPoolExecutor.submit(new MQTTSender(topic, compressMqttMessage));
-            } else {
-                threadPoolExecutor.submit(new MQTTSender(topic, message));
             }
+            threadPoolExecutor.submit(new MQTTSender(topic, message));
         } catch (RejectedExecutionException e) {
             EventAdapterUtil.logAndDrop(eventAdapterConfiguration.getName(), message, "Job queue is full", e, log,
                     tenantId);

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
@@ -38,6 +38,7 @@ import org.wso2.carbon.context.PrivilegedCarbonContext;
 import org.wso2.carbon.event.output.adapter.core.exception.ConnectionUnavailableException;
 import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterException;
 import org.wso2.carbon.event.output.adapter.core.exception.OutputEventAdapterRuntimeException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * MQTT publisher related configuration initialization and publishing capabilties are implemented here.
@@ -94,23 +95,20 @@ public class MQTTAdapterPublisher {
         return mqttClient.isConnected();
     }
 
-    public void publish(int qos, String payload, String topic) {
+    public void publish(int qos, Object message, String topic) {
         try {
-            // Create and configure a message
-            MqttMessage message = new MqttMessage(payload.getBytes());
-            message.setQos(qos);
-            mqttClient.publish(topic, message);
-        } catch (MqttException e) {
-            log.error("Error occurred when publishing message for MQTT server : " + mqttClient.getServerURI(), e);
-            handleException(e);
-        }
-    }
+            byte[] payload;
+            if (message instanceof byte[]) {
+                payload = (byte[]) message;
+            } else {
+                payload = message.toString().getBytes(StandardCharsets.UTF_8);
+            }
 
-    public void publish(String payload, String topic) {
-        try {
-            // Create and configure a message
-            MqttMessage message = new MqttMessage(payload.getBytes());
-            mqttClient.publish(topic, message);
+            MqttMessage mqttMessage = new MqttMessage(payload);
+            if (qos >= 0) {
+                mqttMessage.setQos(qos);
+            }
+            mqttClient.publish(topic, mqttMessage);
         } catch (MqttException e) {
             log.error("Error occurred when publishing message for MQTT server : " + mqttClient.getServerURI(), e);
             handleException(e);

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTUtil.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTUtil.java
@@ -44,7 +44,7 @@ import java.util.zip.GZIPOutputStream;
 public class MQTTUtil {
 	private static final String HTTPS_PROTOCOL = "https";
 	private static final Log log = LogFactory.getLog(MQTTUtil.class);
-	private static final int DEFAULT_COMPRESSION_LEVEL = 1;
+	private static final int DEFAULT_COMPRESSION_LEVEL = 0;
 
 	/**
 	 * Return a http client instance
@@ -87,6 +87,18 @@ public class MQTTUtil {
 		}
 	}
 
+	/**
+	 * Compress the provided byte array using GZIP with the configured compression level.
+	 * <p>
+	 * The compression level is taken from the device configuration (via
+	 * {@code DeviceConfigurationManager.getInstance().getDeviceManagementConfig()
+	 * .getMqttConfiguration().getCompressionLevel()}). If the configured level is invalid,
+	 * {@link #DEFAULT_COMPRESSION_LEVEL} will be used.
+	 *
+	 * @param data the input bytes to compress
+	 * @return the compressed bytes
+	 * @throws IOException if an error occurs during compression
+	 */
 	public static byte[] compressMqttMessage(byte[] data) throws IOException {
 		int configuredCompressionLevel = DeviceConfigurationManager.getInstance().getDeviceManagementConfig()
 				.getMqttConfiguration().getCompressionLevel();

--- a/pom.xml
+++ b/pom.xml
@@ -994,6 +994,7 @@
         <cxf.bindings.version>2.5.11</cxf.bindings.version>
         <cxf-bundle.version>2.6.1.wso2v2</cxf-bundle.version>
         <jackson.version>1.9.13</jackson.version>
+        <fasterxml.jackson.version>2.15.2</fasterxml.jackson.version>
         <javax.ws.rs.version>1.1.1</javax.ws.rs.version>
 
         <!-- Carbon Commons -->


### PR DESCRIPTION
## Purpose
> 
To improve MQTT message reliability and performance.

- Handle incoming MQTT messages safely by adding validations to prevent runtime exceptions during message arrival and processing.
- Reduce MQTT payload size, preventing possible message payload loss or truncation when transmitting large payloads

Related Prs: https://github.com/entgra/device-mgt-core/pull/170
Related Issue ticket: https://roadmap.entgra.net/issues/15144

## Approach
> 
- Automatically compress MQTT payloads larger than 4 KB before transmission to reduce mqtt message.
- Use GZIP compression (level 1) to achieve a balance between compression speed and size optimization.
- Detect compressed messages on the receiver side by searching the payload for GZIP magic bytes (0x1f, 0x8b).
- Support decompression even when compressed data is embedded within mixed or prefixed payload content.
- Maintain backward compatibility with both:
- plain JSON messages, and
- compressed MQTT payloads.
- Implement reusable utility methods for compression and decompression logic to improve maintainability.
- Add validation and error handling to prevent runtime failures during message processing.
- Include debug logging to simplify troubleshooting and payload inspection.
- Add configured compression atributes from cdm 

