### PR TITLE
Customize EMQX Client ID

### DIFF
--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
@@ -25,6 +25,7 @@ import io.entgra.device.mgt.core.apimgt.application.extension.exception.APIManag
 import io.entgra.device.mgt.core.apimgt.extension.rest.api.exceptions.BadRequestException;
 import io.entgra.device.mgt.core.apimgt.extension.rest.api.exceptions.UnexpectedResponseException;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.paho.client.mqttv3.*;
@@ -69,7 +70,7 @@ public class MQTTAdapterListener implements MqttCallback, Runnable {
                                InputEventAdapterListener inputEventAdapterListener) {
         String mqttClientId = inputEventAdapterConfiguration.getProperties()
                 .get(MQTTEventAdapterConstants.ADAPTER_CONF_CLIENTID);
-        if (mqttClientId == null || mqttClientId.trim().isEmpty()) {
+        if (StringUtils.isBlank(mqttClientId)) {
             mqttClientId = MqttClient.generateClientId();
         }
         this.inputEventAdapterConfiguration = inputEventAdapterConfiguration;

--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
@@ -69,8 +69,14 @@ public class MQTTAdapterListener implements MqttCallback, Runnable {
                                InputEventAdapterListener inputEventAdapterListener) {
         String mqttClientId = inputEventAdapterConfiguration.getProperties()
                 .get(MQTTEventAdapterConstants.ADAPTER_CONF_CLIENTID);
+        String customClientId = inputEventAdapterConfiguration.getProperties()
+                .get(MQTTEventAdapterConstants.ADAPTER_CUSTOM_CLIENT_ID);
         if (mqttClientId == null || mqttClientId.trim().isEmpty()) {
-            mqttClientId = MqttClient.generateClientId();
+            if (customClientId != null && !customClientId.trim().isEmpty()) {
+                mqttClientId = customClientId;
+            } else {
+                mqttClientId = MqttClient.generateClientId();
+            }
         }
         this.inputEventAdapterConfiguration = inputEventAdapterConfiguration;
         this.mqttBrokerConnectionConfiguration = mqttBrokerConnectionConfiguration;

--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTEventAdapterConstants.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTEventAdapterConstants.java
@@ -40,6 +40,7 @@ public class MQTTEventAdapterConstants {
     public static final String ADAPTER_CONF_CONTENT_TRANSFORMER_TYPE = "contentTransformer";
     public static final String ADAPTER_CONF_CONTENT_TRANSFORMER_TYPE_HINT = "contentTransformer.hint";
     public static final String ADAPTER_MESSAGE_TOPIC = "topic";
+    public static final String ADAPTER_CUSTOM_CLIENT_ID = "customClientId";
     public static final String ADAPTER_MESSAGE_TOPIC_HINT = "topic.hint";
     public static final String ADAPTER_CONF_CLIENTID = "clientId";
     public static final String ADAPTER_CONF_CLIENTID_HINT = "clientId.hint";

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
@@ -56,15 +56,17 @@ public class MQTTAdapterPublisher {
             , int tenantId) {
         this.tenantId = tenantId;
         this.tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        if (clientId == null || clientId.trim().isEmpty()) {
+        if (StringUtils.isBlank(clientId)) {
             this.clientId = MqttClient.generateClientId();
+        } else {
+            this.clientId = clientId;
         }
         this.mqttBrokerConnectionConfiguration = mqttBrokerConnectionConfiguration;
         connect();
     }
 
     public void connect() {
-        if (clientId == null || clientId.trim().isEmpty()) {
+        if (StringUtils.isBlank(clientId)) {
             clientId = MqttClient.generateClientId();
         }
         boolean cleanSession = mqttBrokerConnectionConfiguration.isCleanSession();

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
@@ -56,16 +56,26 @@ public class MQTTAdapterPublisher {
             , int tenantId) {
         this.tenantId = tenantId;
         this.tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        if (clientId == null || clientId.trim().isEmpty()) {
-            this.clientId = MqttClient.generateClientId();
-        }
         this.mqttBrokerConnectionConfiguration = mqttBrokerConnectionConfiguration;
+        String customClientId = mqttBrokerConnectionConfiguration.getCustomClientId();
+        if (clientId == null || clientId.trim().isEmpty()) {
+            if (customClientId != null && !customClientId.trim().isEmpty()) {
+                this.clientId = customClientId;
+            } else {
+                this.clientId = MqttClient.generateClientId();
+            }
+        }
         connect();
     }
 
     public void connect() {
+        String customClientId = mqttBrokerConnectionConfiguration.getCustomClientId();
         if (clientId == null || clientId.trim().isEmpty()) {
-            clientId = MqttClient.generateClientId();
+            if (customClientId != null && !customClientId.trim().isEmpty()) {
+                clientId = customClientId;
+            } else {
+                clientId = MqttClient.generateClientId();
+            }
         }
         boolean cleanSession = mqttBrokerConnectionConfiguration.isCleanSession();
         int keepAlive = mqttBrokerConnectionConfiguration.getKeepAlive();

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTBrokerConnectionConfiguration.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTBrokerConnectionConfiguration.java
@@ -37,6 +37,7 @@ public class MQTTBrokerConnectionConfiguration {
     private int qos;
 
     private String topic;
+    private String customClientId;
 
     public String getTokenUrl() {
         return tokenUrl;
@@ -86,6 +87,10 @@ public class MQTTBrokerConnectionConfiguration {
         return topic;
     }
 
+    public String getCustomClientId() {
+        return customClientId;
+    }
+
     public MQTTBrokerConnectionConfiguration(OutputEventAdapterConfiguration eventAdapterConfiguration,
                                              Map<String, String> globalProperties) {
         adapterName = eventAdapterConfiguration.getName();
@@ -133,6 +138,12 @@ public class MQTTBrokerConnectionConfiguration {
         String topic = eventAdapterConfiguration.getStaticProperties().get(MQTTEventAdapterConstants.ADAPTER_MESSAGE_TOPIC);
         if (!StringUtils.isEmpty(topic)) {
             this.topic = topic;
+        }
+
+        String customClientId = eventAdapterConfiguration.getStaticProperties()
+                .get(MQTTEventAdapterConstants.ADAPTER_CUSTOM_CLIENT_ID);
+        if (!StringUtils.isEmpty(customClientId)) {
+            this.customClientId = customClientId;
         }
     }
 

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTEventAdapterConstants.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTEventAdapterConstants.java
@@ -43,6 +43,7 @@ public final class MQTTEventAdapterConstants {
     public static final String ADAPTER_TEMP_DIRECTORY_NAME = "java.io.tmpdir";
     public static final String ADAPTER_CONF_CLIENTID = "clientId";
     public static final String ADAPTER_CONF_CLIENTID_HINT = "clientId.hint";
+    public static final String ADAPTER_CUSTOM_CLIENT_ID = "customClientId";
     public static final String EMPTY_STRING = "";
     public static final String ADAPTER_CONF_KEEP_ALIVE = "keepAliveTimeInMillis";
     public static final int ADAPTER_CONF_DEFAULT_KEEP_ALIVE = 60000;


### PR DESCRIPTION

**Purpose:**  
Allow MQTT adapters to use a configurable EMQX client ID instead of always relying on the default `clientId` property or an auto-generated Paho client ID.

**Goals:**  
- Support a new `customClientId` configuration.
- Keep backward compatibility with existing `clientId` behavior.

**Approach:**  
The commit adds `ADAPTER_CUSTOM_CLIENT_ID = "customClientId"` to MQTT adapter constants. In [MQTTAdapterListener.java](/home/msi/Desktop/Fork/device-mgt-plugins/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java), the listener now resolves the MQTT client ID in this order:

1. Use configured `clientId` if present.
2. Otherwise use `customClientId` if present.
3. Otherwise generate a client ID with `MqttClient.generateClientId()`.

The same idea is applied to the output MQTT publisher by storing `customClientId` in the broker configuration and using it during publisher connection setup.