### PR TITLE
Fix MQTT Adapters to Use Configured Client ID

### DIFF
--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/pom.xml
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/pom.xml
@@ -127,6 +127,7 @@
                             javax.net.ssl,
                             org.apache.axis2.context;version="[1.6,2)",
                             org.apache.commons.codec.binary;version="[1.4,2)",
+                            org.apache.commons.lang;version="[2.6,3)",
                             org.apache.commons.logging;version="[1.2,2)",
                             org.apache.http;version="[4.4,5)",
                             org.apache.http.client;version="[4.3,5)",

--- a/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
+++ b/components/extensions/cdmf-transport-adapters/input/io.entgra.device.mgt.plugins.input.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/input/adapter/mqtt/util/MQTTAdapterListener.java
@@ -25,6 +25,7 @@ import io.entgra.device.mgt.core.apimgt.application.extension.exception.APIManag
 import io.entgra.device.mgt.core.apimgt.extension.rest.api.exceptions.BadRequestException;
 import io.entgra.device.mgt.core.apimgt.extension.rest.api.exceptions.UnexpectedResponseException;
 import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.eclipse.paho.client.mqttv3.*;
@@ -69,7 +70,7 @@ public class MQTTAdapterListener implements MqttCallback, Runnable {
                                InputEventAdapterListener inputEventAdapterListener) {
         String mqttClientId = inputEventAdapterConfiguration.getProperties()
                 .get(MQTTEventAdapterConstants.ADAPTER_CONF_CLIENTID);
-        if (mqttClientId == null || mqttClientId.trim().isEmpty()) {
+        if (StringUtils.isBlank(mqttClientId)) {
             mqttClientId = MqttClient.generateClientId();
         }
         this.inputEventAdapterConfiguration = inputEventAdapterConfiguration;

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/pom.xml
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/pom.xml
@@ -116,6 +116,7 @@
                             io.entgra.device.mgt.plugins.output.adapter.mqtt,
                             io.entgra.device.mgt.plugins.output.adapter.mqtt.util,
                             javax.net.ssl,
+                            org.apache.commons.lang;version="[2.6,3)",
                             org.apache.commons.logging;version="[1.2,2)",
                             org.apache.commons.ssl;version="[3.1,4)",
                             org.apache.http;version="[4.4,5)",

--- a/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
+++ b/components/extensions/cdmf-transport-adapters/output/io.entgra.device.mgt.plugins.output.adapter.mqtt/src/main/java/io/entgra/device/mgt/plugins/output/adapter/mqtt/util/MQTTAdapterPublisher.java
@@ -56,15 +56,17 @@ public class MQTTAdapterPublisher {
             , int tenantId) {
         this.tenantId = tenantId;
         this.tenantDomain = PrivilegedCarbonContext.getThreadLocalCarbonContext().getTenantDomain();
-        if (clientId == null || clientId.trim().isEmpty()) {
+        if (StringUtils.isBlank(clientId)) {
             this.clientId = MqttClient.generateClientId();
+        } else {
+            this.clientId = clientId;
         }
         this.mqttBrokerConnectionConfiguration = mqttBrokerConnectionConfiguration;
         connect();
     }
 
     public void connect() {
-        if (clientId == null || clientId.trim().isEmpty()) {
+        if (StringUtils.isBlank(clientId)) {
             clientId = MqttClient.generateClientId();
         }
         boolean cleanSession = mqttBrokerConnectionConfiguration.isCleanSession();


### PR DESCRIPTION

**Purpose:**  
Fix MQTT adapters so the existing configured clientId is actually used for EMQX connections instead of falling back to an auto-generated Paho client ID.

**Goals:**  
- Preserve existing clientId configuration behavior.
- Generate a client ID only when no valid clientId is configured.
- Handle null, empty, and whitespace-only values consistently.

**Approach:**  
The MQTT adapter client ID resolution was updated to prefer the configured clientId and fall back to a generated client ID only when the configured value is blank. The blank checks were simplified with StringUtils.isBlank() for consistent handling across input and output MQTT adapters.